### PR TITLE
Decoupling from log.Logger

### DIFF
--- a/opbeat.go
+++ b/opbeat.go
@@ -159,7 +159,7 @@ func NewFromEnvironment() *Opbeat {
 	return opbeat
 }
 
-// New creates a new Opbeat client with a logger of your choice
+// NewWithLogger creates a new Opbeat client with a logger of your choice
 func NewWithLogger(organizationID, appID, secretToken string, logger StdLogger) *Opbeat {
 	opbeat := new(Opbeat)
 	opbeat.Credentials(organizationID, appID, secretToken)

--- a/opbeat.go
+++ b/opbeat.go
@@ -118,10 +118,10 @@ type Opbeat struct {
 	packets                            chan *packet
 	wait                               sync.WaitGroup
 	organizationID, appID, secretToken string
+	logger                             StdLogger
 	Host                               string
 	Revision                           string
 	LoggerName                         string
-	Logger                             StdLogger
 	*http.Client
 }
 
@@ -149,8 +149,8 @@ func NewFromEnvironment() *Opbeat {
 	timeout := os.Getenv("OPBEAT_TIMEOUT")
 	if len(timeout) > 0 {
 		timeoutSec, err := strconv.Atoi(timeout)
-		if err != nil && opbeat.Logger != nil {
-			opbeat.Logger.Print(err)
+		if err != nil && opbeat.logger != nil {
+			opbeat.logger.Print(err)
 		} else {
 			opbeat.Client.Timeout = time.Duration(timeoutSec) * time.Second
 		}
@@ -159,7 +159,7 @@ func NewFromEnvironment() *Opbeat {
 	return opbeat
 }
 
-// NewWithLogger creates a new Opbeat client with a logger of your choice
+// NewWithLogger creates a new Opbeat client with a logger of your choice.
 func NewWithLogger(organizationID, appID, secretToken string, logger StdLogger) *Opbeat {
 	opbeat := new(Opbeat)
 	opbeat.Credentials(organizationID, appID, secretToken)
@@ -170,7 +170,7 @@ func NewWithLogger(organizationID, appID, secretToken string, logger StdLogger) 
 	}
 
 	opbeat.LoggerName = "default"
-	opbeat.Logger = logger
+	opbeat.logger = logger
 
 	opbeat.start()
 
@@ -296,8 +296,8 @@ func (opbeat *Opbeat) start() {
 					return
 				}
 				err := opbeat.send(p)
-				if err != nil && opbeat.Logger != nil {
-					opbeat.Logger.Println(err)
+				if err != nil && opbeat.logger != nil {
+					opbeat.logger.Println(err)
 				}
 				opbeat.wait.Done()
 			}
@@ -350,8 +350,8 @@ func (opbeat *Opbeat) send(p *packet) error {
 
 	switch res.StatusCode {
 	case 202:
-		if res.Header["Location"] != nil && opbeat.Logger != nil {
-			opbeat.Logger.Printf("Event details at %s", res.Header["Location"][0])
+		if res.Header["Location"] != nil && opbeat.logger != nil {
+			opbeat.logger.Printf("Event details at %s", res.Header["Location"][0])
 		}
 		return nil
 	default:

--- a/opbeat_test.go
+++ b/opbeat_test.go
@@ -2,8 +2,10 @@ package opbeat
 
 import (
 	"errors"
+	"log"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"os/exec"
 	"testing"
 )
@@ -95,6 +97,35 @@ func TestRevision(t *testing.T) {
 	DefaultClient.Revision = string(rev[:])
 
 	err = CaptureError(errors.New("Capturing Revision"), nil)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestNewWithLogger(t *testing.T) {
+	logger := log.New(os.Stderr, "", log.LstdFlags)
+
+	opbeat := NewWithLogger("organizationID", "appID", "secretToken", logger)
+
+	if opbeat.Logger != logger {
+		t.Error("Logger should be set by when calling NewWithLogger")
+	}
+}
+
+func TestLoggerIsSetByDefault(t *testing.T) {
+	opbeat := New("organizationID", "appID", "secretToken")
+
+	if opbeat.Logger == nil {
+		t.Error("Logger should be set by default")
+	}
+}
+
+func TestCaptureMessageWithNilLogger(t *testing.T) {
+	defer Wait()
+
+	opbeat := NewWithLogger("organizationID", "appID", "secretToken", nil)
+
+	err := opbeat.CaptureMessage("Test Message", Info, nil)
 	if err != nil {
 		t.Error(err)
 	}

--- a/opbeat_test.go
+++ b/opbeat_test.go
@@ -107,7 +107,7 @@ func TestNewWithLogger(t *testing.T) {
 
 	opbeat := NewWithLogger("organizationID", "appID", "secretToken", logger)
 
-	if opbeat.Logger != logger {
+	if opbeat.logger != logger {
 		t.Error("Logger should be set by when calling NewWithLogger")
 	}
 }
@@ -115,7 +115,7 @@ func TestNewWithLogger(t *testing.T) {
 func TestLoggerIsSetByDefault(t *testing.T) {
 	opbeat := New("organizationID", "appID", "secretToken")
 
-	if opbeat.Logger == nil {
+	if opbeat.logger == nil {
 		t.Error("Logger should be set by default")
 	}
 }


### PR DESCRIPTION
Introduced NewWithLogger which takes the StdLogger interface from Sirupsens LogRus.
This also makes it possible to disable logging completely by passing nil to NewWithLogger.